### PR TITLE
replaced pageYOffset with scrollY

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -573,7 +573,7 @@ class TaikoLibWindowatch {
    * @memberof TaikoLibWindowatch
    */
   protected windowDidScroll = (): void => {
-    const scrollY = window.pageYOffset;
+    const scrollY = window.scrollY;
 
     if (this.scrollY === scrollY) {
       // nothing changed, nothing to do


### PR DESCRIPTION
The read-only property `pageYOffset` is an alias for `scrollY`. There is slightly better support for `pageYOffset` than for `scrollY` in older browsers. See https://caniuse.com/?search=pageYOffset